### PR TITLE
Fix rsync options to check new targets

### DIFF
--- a/fcompare.sh
+++ b/fcompare.sh
@@ -62,12 +62,12 @@ fi
 # Step 1: Build file list
 if $RECURSIVE; then
   # full recursive, rsync dry-run
-  rsync -avun --checksum $EXCLUDE_OPTION "$SOURCE/" "$TARGET/" \
+  rsync -avn --checksum $EXCLUDE_OPTION "$SOURCE/" "$TARGET/" \
     | grep -v '/$' | grep -vE '^(sending incremental file list|\.\/|^$)' \
     > "$RSYNC_RESULT"
 else
   # root-only dry-run: skip all directories
-  rsync -avun --checksum --exclude '*/' $EXCLUDE_OPTION \
+  rsync -avn --checksum --exclude '*/' $EXCLUDE_OPTION \
     "$SOURCE/" "$TARGET/" \
     | grep -vE '^(sending incremental file list|\.\/|^$)' \
     > "$RSYNC_RESULT"


### PR DESCRIPTION
## Summary
- adjust rsync dry-run flags so files are compared even when the destination copy is newer

## Testing
- `bash fcompare.sh -r -s test/src -d test/dst -n t1 -o test/out` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cbee59fc832480aef677bd5dc24c